### PR TITLE
Mend will no longer require a point trained to skill up.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5052,6 +5052,7 @@ void Client::Handle_OP_InstillDoubt(const EQApplicationPacket *app)
 	p_timers.Start(pTimerInstillDoubt, InstillDoubtReuseTime - 1);
 
 	InstillDoubt(GetTarget());
+	CheckIncreaseSkill(SkillIntimidation, GetTarget(), 10);
 	return;
 }
 
@@ -5251,7 +5252,7 @@ void Client::Handle_OP_Mend(const EQApplicationPacket *app)
 {
 	if (Admin() >= RuleI(GM, NoCombatLow) && Admin()<= RuleI(GM, NoCombatHigh) && Admin() != 0) return;
 
-	if (!HasSkill(SkillMend))
+	if (GetClass() != MONK)
 		return;
 
 	if (!p_timers.Expired(&database, pTimerMend, false)) {

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -2932,12 +2932,16 @@ void command_reloadqst(Client *c, const Seperator *sep){
 }
 
 void command_reloadworld(Client *c, const Seperator *sep){
-	c->Message(0, "Reloading quest cache, reloading rules, and repopping zones worldwide.");
+	//c->Message(0, "Reloading quest cache, reloading rules, and repopping zones worldwide.");
 	ServerPacket* pack = new ServerPacket(ServerOP_ReloadWorld, sizeof(ReloadWorld_Struct));
 	ReloadWorld_Struct* RW = (ReloadWorld_Struct*) pack->pBuffer;
-	RW->Option = ((atoi(sep->arg[1]) == 1) ? 1 : 0);
+	RW->Option = 0; //Keep it, maybe we'll use it in the future.
 	worldserver.SendPacket(pack);
 	safe_delete(pack);
+	if (!worldserver.SendChannelMessage(c, 0, 6, 0, 0, "Reloading quest cache, reloading rules, and repopping zones worldwide."))
+		c->Message(0, "Error: World server disconnected");
+
+	c->Message(CC_Yellow, "You broadcast, Reloading quest cache, reloading rules, and repopping zones worldwide.");
 }
 
 void command_reloadlevelmods(Client *c, const Seperator *sep){

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -354,6 +354,7 @@ Mob::Mob(const char* in_name,
 	count_TempPet = 0;
 
 	m_is_running = false;
+	m_running = false;
 
 	nimbus_effect1 = 0;
 	nimbus_effect2 = 0;
@@ -1156,7 +1157,7 @@ void Mob::ShowStats(Client* client)
 			client->Message(0, "  EmoteID: %i Trackable: %i SeeInvis: %i SeeInvUndead: %i SeeHide: %i SeeImpHide: %i", n->GetEmoteID(), n->IsTrackable(), n->SeeInvisible(), n->SeeInvisibleUndead(), n->SeeHide(), n->SeeImprovedHide());
 			client->Message(0, "  CanEquipSec: %i DualWield: %i KickDmg: %i BashDmg: %i HasShield: %i", n->CanEquipSecondary(), n->CanDualWield(), n->GetKickDamage(), n->GetBashDamage(), n->HasShieldEquiped());
 			client->Message(0, "  PriSkill: %i SecSkill: %i PriMelee: %i SecMelee: %i", n->GetPrimSkill(), n->GetSecSkill(), n->GetPrimaryMeleeTexture(), n->GetSecondaryMeleeTexture());
-			client->Message(0, "  Runspeed: %f Walkspeed: %f RunSpeedAnim: %i Running: %i MovementSpeed: %f", GetRunspeed(), GetWalkspeed(), GetRunAnimSpeed(), IsRunning(), GetMovespeed());
+			client->Message(0, "  Runspeed: %f Walkspeed: %f RunSpeedAnim: %i Running: %i MovementSpeed: %f", GetRunspeed(), GetWalkspeed(), GetRunAnimSpeed(), IsCurrentlyRunning(), GetMovespeed());
 			if(flee_mode)
 				client->Message(0, "  Fleespeed: %f", n->GetFearSpeed());
 			n->QueryLoot(client);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -423,6 +423,8 @@ public:
 	float GetMovespeed() const { return IsRunning() ? GetRunspeed() : GetWalkspeed(); }
 	bool IsRunning() const { return m_is_running; }
 	void SetRunning(bool val) { m_is_running = val; }
+	bool IsCurrentlyRunning() const { return m_running; }
+	void SetCurrentlyRunning(bool val) { m_running = val; }
 	virtual void GMMove(float x, float y, float z, float heading = 0.01, bool SendUpdate = true);
 	void SetDeltas(float delta_x, float delta_y, float delta_z, float delta_h);
 	void SetTargetDestSteps(uint8 target_steps) { tar_ndx = target_steps; }
@@ -1057,7 +1059,8 @@ protected:
 	float fixedZ;
 	EmuAppearance _appearance;
 	uint8 pRunAnimSpeed;
-	bool m_is_running;
+	bool m_is_running; // This bool tells us if the NPC *should* be running or walking, to calculate speed.
+	bool m_running; // This bool is used to tell us if the NPC is currently running or walking.
 
 
 	Timer attack_timer;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1927,10 +1927,6 @@ void Mob::InstillDoubt(Mob *who) {
 	if(!CombatRange(who))
 		return;
 
-	if(IsClient()) {
-		CastToClient()->CheckIncreaseSkill(SkillIntimidation, who, 10);
-	}
-
 	//I think this formula needs work
 	int value = 0;
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -428,8 +428,7 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, uint16 slot,
 	// check line of sight to target if it's a detrimental spell
 	if(spell_target && spells[spell_id].targettype != ST_TargetOptional && spells[spell_id].targettype != ST_Self && spells[spell_id].targettype != ST_AECaster)
 	{
-		if((zone->IsCity() || !zone->CanCastOutdoor()) && 
-		IsDetrimentalSpell(spell_id) && !CheckLosFN(spell_target) && !IsHarmonySpell(spell_id) && 
+		if(!zone->SkipLoS() && IsDetrimentalSpell(spell_id) && !CheckLosFN(spell_target) && !IsHarmonySpell(spell_id) && 
 		!IsBindSightSpell(spell_id))
 		{
 			mlog(SPELLS__CASTING, "Spell %d: cannot see target %s", spell_id, spell_target->GetName());
@@ -2255,8 +2254,7 @@ bool Mob::ApplyNextBardPulse(uint16 spell_id, Mob *spell_target, uint16 slot) {
 		if(!CheckRegion(spell_target))
 			return(false);
 
-		if((zone->IsCity() || !zone->CanCastOutdoor()) &&
-		IsDetrimentalSpell(spell_id) && !CheckLosFN(spell_target) && !IsHarmonySpell(spell_id) && 
+		if(!zone->SkipLoS() && IsDetrimentalSpell(spell_id) && !CheckLosFN(spell_target) && !IsHarmonySpell(spell_id) && 
 		!IsBindSightSpell(spell_id))
 		{
 			mlog(SPELLS__CASTING, "Bard Song Pulse %d: cannot see target %s", spell_target->GetName());

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -747,13 +747,13 @@ float Mob::SetRunAnimation(float speed)
 	{
 		if(speed == GetRunspeed())
 		{
-			SetRunning(true);
+			SetCurrentlyRunning(true);
 			newspeed = speed * RuleR(NPC, SpeedMultiplier);
 			pRunAnimSpeed = (int8)(speed*RuleI(NPC, RunAnimRatio));
 		}
 		else
 		{
-			SetRunning(false);
+			SetCurrentlyRunning(false);
 			newspeed = speed * RuleR(NPC, WalkSpeedMultiplier);
 			pRunAnimSpeed = (int8)(speed*RuleI(NPC, WalkAnimRatio));
 		}

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -901,7 +901,7 @@ bool Zone::LoadZoneCFG(const char* filename, uint16 instance_id, bool DontLoadDe
 	{
 		map_name = nullptr;
 		if(!database.GetZoneCFG(database.GetZoneID(filename), 0, &newzone_data, can_bind,
-			can_combat, can_levitate, can_castoutdoor, is_city, is_hotzone, zone_type, default_ruleset, &map_name, can_bind_others))
+			can_combat, can_levitate, can_castoutdoor, is_city, is_hotzone, zone_type, default_ruleset, &map_name, can_bind_others, skip_los))
 		{
 			LogFile->write(EQEMuLog::Error, "Error loading the Zone Config.");
 			return false;
@@ -912,11 +912,11 @@ bool Zone::LoadZoneCFG(const char* filename, uint16 instance_id, bool DontLoadDe
 		//Fall back to base zone if we don't find the instance version.
 		map_name = nullptr;
 		if(!database.GetZoneCFG(database.GetZoneID(filename), instance_id, &newzone_data, can_bind,
-			can_combat, can_levitate, can_castoutdoor, is_city, is_hotzone,  zone_type, default_ruleset, &map_name, can_bind_others))
+			can_combat, can_levitate, can_castoutdoor, is_city, is_hotzone,  zone_type, default_ruleset, &map_name, can_bind_others, skip_los))
 		{
 			safe_delete_array(map_name);
 			if(!database.GetZoneCFG(database.GetZoneID(filename), 0, &newzone_data, can_bind,
-			can_combat, can_levitate, can_castoutdoor, is_city, is_hotzone,  zone_type, default_ruleset, &map_name, can_bind_others))
+			can_combat, can_levitate, can_castoutdoor, is_city, is_hotzone,  zone_type, default_ruleset, &map_name, can_bind_others, skip_los))
 			{
 				LogFile->write(EQEMuLog::Error, "Error loading the Zone Config.");
 				return false;
@@ -1853,11 +1853,7 @@ void Zone::ReloadWorld(uint32 Option){
 		entity_list.ClearAreas();
 		parse->ReloadQuests();
 		RuleManager::Instance()->LoadRules(&database, RuleManager::Instance()->GetActiveRuleset());
-	} else if(Option == 1) {
 		zone->Repop(0);
-		entity_list.ClearAreas();
-		parse->ReloadQuests();
-		RuleManager::Instance()->LoadRules(&database, RuleManager::Instance()->GetActiveRuleset());
 	}
 }
 

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -212,6 +212,7 @@ public:
 	bool	IsBoatZone();
 	bool	IsDesertZone();
 	bool	IsBindArea(float x_coord, float y_coord);
+	bool	SkipLoS() const { return(skip_los); }
 	inline	bool BuffTimersSuspended() const { return newzone_data.SuspendBuffs != 0; };
 
 	time_t	weather_timer;
@@ -276,6 +277,7 @@ private:
 	bool	can_castoutdoor;
 	bool	can_levitate;
 	bool	is_hotzone;
+	bool	skip_los; // Zone does not do a LOS spell check.
 	uint8	zone_type;
 	uint32	pgraveyard_id, pgraveyard_zoneid;
 	float	pgraveyard_x, pgraveyard_y, pgraveyard_z, pgraveyard_heading;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -94,7 +94,7 @@ bool ZoneDatabase::SaveZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct
 	return true;
 }
 
-bool ZoneDatabase::GetZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct *zone_data, bool &can_bind, bool &can_combat, bool &can_levitate, bool &can_castoutdoor, bool &is_city, bool &is_hotzone, uint8 &zone_type, int &ruleset, char **map_filename, bool &can_bind_others) {
+bool ZoneDatabase::GetZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct *zone_data, bool &can_bind, bool &can_combat, bool &can_levitate, bool &can_castoutdoor, bool &is_city, bool &is_hotzone, uint8 &zone_type, int &ruleset, char **map_filename, bool &can_bind_others, bool &skip_los) {
 
 	*map_filename = new char[100];
 	zone_data->zone_id = zoneid;
@@ -109,7 +109,7 @@ bool ZoneDatabase::GetZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct 
                                     "rain_chance1, rain_chance2, rain_chance3, rain_chance4, " // 4
                                     "rain_duration1, rain_duration2, rain_duration3, rain_duration4, " // 4
                                     "snow_chance1, snow_chance2, snow_chance3, snow_chance4, " // 4
-                                    "snow_duration1, snow_duration2, snow_duration3, snow_duration4 " // 4
+                                    "snow_duration1, snow_duration2, snow_duration3, snow_duration4, skip_los " // 4
                                     "FROM zone WHERE zoneidnumber = %i AND version = %i", zoneid, instance_id);
     auto results = QueryDatabase(query);
     if (!results.Success()) {
@@ -184,6 +184,8 @@ bool ZoneDatabase::GetZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct 
 
 	for(index = 0; index < 4; index++)
         zone_data->snow_duration[index]=atof(row[52 + index]);
+
+	skip_los = atoi(row[56]) == 0? false: true;
 
 	return true;
 }

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -277,7 +277,7 @@ public:
 	void FillAAEffects(SendAA_Struct* aa_struct);
 
 	/* Zone related */
-	bool	GetZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct *data, bool &can_bind, bool &can_combat, bool &can_levitate, bool &can_castoutdoor, bool &is_city, bool &is_hotzone, uint8 &zone_type, int &ruleset, char **map_filename, bool &can_bind_others);
+	bool	GetZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct *data, bool &can_bind, bool &can_combat, bool &can_levitate, bool &can_castoutdoor, bool &is_city, bool &is_hotzone, uint8 &zone_type, int &ruleset, char **map_filename, bool &can_bind_others, bool &skip_los);
 	bool	SaveZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct* zd);
 	bool	LoadStaticZonePoints(LinkedList<ZonePoint*>* zone_point_list,const char* zonename, uint32 version);
 	bool	UpdateZoneSafeCoords(const char* zonename, float x, float y, float z);


### PR DESCRIPTION
#reloadworld will now automatically repop and broadcast a warning to players.

Fixed a problem that was causing NPCs in a roambox or on a grid from never walking again after aggro.

Added skip_los field to zone, so we can specify which zones skip LOS check for spells easily. Required DB changes are already merged into the datbase.