### PR TITLE
XP loss on death should be closer to AK values.

### DIFF
--- a/common/patches/mac.cpp
+++ b/common/patches/mac.cpp
@@ -1064,10 +1064,10 @@ namespace Mac {
 			delete in;
 			return;
 		}
-		if(itemcount > 80)
-			itemcount = 80;
+		if(itemcount > 79)
+			itemcount = 79;
 
-		int pisize = sizeof(structs::MerchantItems_Struct) + (80 * sizeof(structs::MerchantItemsPacket_Struct));
+		int pisize = sizeof(structs::MerchantItems_Struct) + (79 * sizeof(structs::MerchantItemsPacket_Struct));
 		structs::MerchantItems_Struct* pi = (structs::MerchantItems_Struct*) new uchar[pisize];
 		memset(pi, 0, pisize);
 

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -27,8 +27,6 @@ RULE_INT ( Character, MaxExpLevel, 0 ) //Sets the Max Level attainable via Exper
 RULE_INT ( Character, DeathExpLossLevel, 10 )	// Any level greater than this will lose exp on death
 RULE_INT ( Character, DeathExpLossMaxLevel, 255 )	// Any level greater than this will no longer lose exp on death
 RULE_INT ( Character, DeathItemLossLevel, 10 )
-RULE_INT ( Character, DeathExpLossMultiplier, 3) //Adjust how much exp is lost
-RULE_BOOL( Character, UseDeathExpLossMult, false ) //Adjust to use the above multiplier or to use code default.
 RULE_INT ( Character, CorpseDecayTimeMS, 604800000 ) // 7 days
 RULE_INT ( Character, EmptyCorpseDecayTimeMS, 10800000 ) // 3 hours
 RULE_INT ( Character, CorpseResTimeMS, 10800000 ) // time before cant res corpse(3 hours)

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -200,8 +200,12 @@ bool IsHasteSpell(uint16 spell_id)
 
 bool IsHarmonySpell(uint16 spell_id)
 {
-	// IsEffectInSpell(spell_id, SE_Lull) - Lull is not calculated anywhere atm
 	return (IsEffectInSpell(spell_id, SE_Harmony) || IsEffectInSpell(spell_id, SE_ChangeFrenzyRad));
+}
+
+bool IsPacifySpell(uint16 spell_id)
+{
+	return IsEffectInSpell(spell_id, SE_ChangeFrenzyRad);
 }
 
 bool IsPercentalHealSpell(uint16 spell_id)

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -772,6 +772,7 @@ bool IsStunSpell(uint16 spell_id);
 bool IsSlowSpell(uint16 spell_id);
 bool IsHasteSpell(uint16 spell_id);
 bool IsHarmonySpell(uint16 spell_id);
+bool IsPacifySpell(uint16 spell_id);
 bool IsPercentalHealSpell(uint16 spell_id);
 bool IsGroupOnlySpell(uint16 spell_id);
 bool IsBeneficialSpell(uint16 spell_id);

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1490,49 +1490,9 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, SkillUseTypes att
 	/*
 		#3: exp loss and corpse generation
 	*/
+	if(IsClient())
+		CastToClient()->GetExpLoss(killerMob, spell, exploss);
 
-	// figure out if they should lose exp
-	if(RuleB(Character, UseDeathExpLossMult)){
-		float GetNum [] = {0.005f,0.015f,0.025f,0.035f,0.045f,0.055f,0.065f,0.075f,0.085f,0.095f,0.110f };
-		int Num = RuleI(Character, DeathExpLossMultiplier);
-		if((Num < 0) || (Num > 10))
-			Num = 3;
-		float loss = GetNum[Num];
-		exploss=(int)((float)GetEXP() * (loss)); //loose % of total XP pending rule (choose 0-10)
-	}
-
-	if(!RuleB(Character, UseDeathExpLossMult)){
-		exploss = (int)(GetLevel() * (GetLevel() / 18.0) * 12000);
-	}
-
-	if( (GetLevel() < RuleI(Character, DeathExpLossLevel)) || (GetLevel() > RuleI(Character, DeathExpLossMaxLevel)) || IsBecomeNPC() )
-	{
-		exploss = 0;
-	}
-	else if( killerMob )
-	{
-		if( killerMob->IsClient() )
-		{
-			exploss = 0;
-		}
-		else if( killerMob->GetOwner() && killerMob->GetOwner()->IsClient() )
-		{
-			exploss = 0;
-		}
-	}
-
-	if(spell != SPELL_UNKNOWN)
-	{
-		uint32 buff_count = GetMaxTotalSlots();
-		for(uint16 buffIt = 0; buffIt < buff_count; buffIt++)
-		{
-			if(buffs[buffIt].spellid == spell && buffs[buffIt].client)
-			{
-				exploss = 0;	// no exp loss for pvp dot
-				break;
-			}
-		}
-	}
 	SetMana(GetMaxMana());
 
 	bool LeftCorpse = false;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4685,6 +4685,13 @@ void Client::SendStatsWindow(Client* client, bool use_window)
 	client->Message(0, " BaseRace: %i  Gender: %i  BaseGender: %i Texture: %i  HelmTexture: %i", GetBaseRace(), GetGender(), GetBaseGender(), GetTexture(), GetHelmTexture());
 	if (client->Admin() >= 100) {
 		client->Message(0, "  CharID: %i  EntityID: %i  PetID: %i  OwnerID: %i  AIControlled: %i  Targetted: %i", CharacterID(), GetID(), GetPetID(), GetOwnerID(), IsAIControlled(), targeted);
+		uint32 xpneeded = GetEXPForLevel(GetLevel()+1) - GetEXP();
+		int exploss;
+		GetExpLoss(nullptr,0,exploss);
+		if(GetLevel() < 10)
+			exploss = 0;
+		client->Message(0, "  CurrentXP: %i XP Needed: %i ExpLoss: %i CurrentAA: %i", GetEXP(), xpneeded, exploss, GetAAXP());
+
 	}
 }
 
@@ -5548,4 +5555,61 @@ bool Client::Disarm(Client* client)
 		}
 	}
 	return false;
+}
+
+void Client::GetExpLoss(Mob* killerMob, uint16 spell, int &exploss)
+{
+	float GetNum [] = {0.16f, 0.08f, 0.15f, 0.075f, 0.14f, 0.07f, 0.13f, 0.065f, 0.12f, 0.06f};
+	float loss;
+	if(GetLevel() >= 1 && GetLevel() <= 29)
+		loss = GetNum[0];
+	if(GetLevel() == 30)
+		loss = GetNum[1];
+	if(GetLevel() >= 31 && GetLevel() <= 34)
+		loss = GetNum[2];
+	if(GetLevel() == 35)
+		loss = GetNum[3];
+	if(GetLevel() >= 36 && GetLevel() <= 39)
+		loss = GetNum[4];
+	if(GetLevel() == 40)
+		loss = GetNum[5];
+	if(GetLevel() >= 41 && GetLevel() <= 44)
+		loss = GetNum[6];
+	if(GetLevel() == 45)
+		loss = GetNum[7];
+	if(GetLevel() >= 46 && GetLevel() <= 50)
+		loss = GetNum[8];
+	if(GetLevel() >= 51)
+		loss = GetNum[9];
+	int requiredxp = GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel());
+	exploss=(int)((float)requiredxp * (loss));
+
+	if( (GetLevel() < RuleI(Character, DeathExpLossLevel)) || (GetLevel() > RuleI(Character, DeathExpLossMaxLevel)) || IsBecomeNPC() )
+	{
+		exploss = 0;
+	}
+	else if( killerMob )
+	{
+		if( killerMob->IsClient() )
+		{
+			exploss = 0;
+		}
+		else if( killerMob->GetOwner() && killerMob->GetOwner()->IsClient() )
+		{
+			exploss = 0;
+		}
+	}
+
+	if(spell != SPELL_UNKNOWN)
+	{
+		uint32 buff_count = GetMaxTotalSlots();
+		for(uint16 buffIt = 0; buffIt < buff_count; buffIt++)
+		{
+			if(buffs[buffIt].spellid == spell && buffs[buffIt].client)
+			{
+				exploss = 0;	// no exp loss for pvp dot
+				break;
+			}
+		}
+	}
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -495,6 +495,8 @@ public:
 	uint32	GetRaidEXP() { return(m_pp.raid_leadership_exp); }
 	uint32	GetGroupEXP() { return(m_pp.group_leadership_exp); }
 	virtual void SetLevel(uint8 set_level, bool command = false);
+	void	GetExpLoss(Mob* attacker, uint16 spell, int &exploss);
+	uint32  GetEXPForLevel(uint16 level);
 
 	void GoToBind(uint8 bindnum = 0);
 	void GoToSafeCoords(uint16 zone_id, uint16 instance_id);
@@ -1069,7 +1071,6 @@ private:
 	PetInfo						m_suspendedminion; // pet data for our suspended minion.
 
 	void NPCSpawn(const Seperator* sep);
-	uint32 GetEXPForLevel(uint16 level);
 
 	bool CanBeInZone();
 	void SendLogoutPackets();

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4962,7 +4962,11 @@ void Client::Handle_OP_Hide(const EQApplicationPacket *app)
 	sa_out->spawn_id = GetID();
 	sa_out->type = AT_Invis;
 	sa_out->parameter = hidden;
-	entity_list.QueueClients(this, outapp);
+
+	if(!hidden && GetClass() != ROGUE)
+		entity_list.QueueClients(this, outapp, true);
+	else
+		entity_list.QueueClients(this, outapp);
 	safe_delete(outapp);
 
 	return;

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -824,7 +824,7 @@ void Client::BulkSendItems()
 
 void Client::BulkSendMerchantInventory(int merchant_id, int npcid) {
 	const Item_Struct* handyitem = nullptr;
-	uint32 numItemSlots = 80; //The max number of items passed in the transaction.
+	uint32 numItemSlots = 79; //The max number of items passed in the transaction.
 	const Item_Struct *item;
 	std::list<MerchantList> merlist = zone->merchanttable[merchant_id];
 	std::list<MerchantList>::const_iterator itr;

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -3938,13 +3938,41 @@ void command_setxp(Client *c, const Seperator *sep){
 		t = c->GetTarget()->CastToClient();
 
 	if (sep->IsNumber(1)) {
-		if (atoi(sep->arg[1]) > 9999999)
+		int exploss;
+		t->GetExpLoss(nullptr,0,exploss);
+		uint32 currentXP = t->GetEXP();
+		int input = atoi(sep->arg[1]);
+
+		if (input > 9999999)
 			c->Message(0, "Error: Value too high.");
+		else if(input == -1)
+		{
+			uint32 newxp = currentXP - exploss;
+			if(newxp < 1000)
+				newxp = 1000;
+			t->SetEXP(newxp, 0);
+		}
+		else if(input == 0)
+		{
+			uint32 newxp = currentXP + exploss;
+			t->SetEXP(newxp, 0);
+		}
+		else if(input <= 100)
+		{
+			float percent = input/100.0f;
+			uint32 requiredxp = t->GetEXPForLevel(t->GetLevel()+1) - t->GetEXPForLevel(t->GetLevel());
+			float final_ = requiredxp*percent;
+			uint32 newxp = (uint32)final_ + currentXP;
+			t->SetEXP(newxp, 0);
+		}
 		else
-			t->AddEXP(atoi(sep->arg[1]));
+		{
+			uint32 newxp = currentXP + input;
+			t->SetEXP(newxp, 0);
+		}
 	}
 	else
-		c->Message(0, "Usage: #setxp number");
+		c->Message(0, "Usage: #setxp number or percentage. If 0, will 'rez' a single death. If -1 will subtract a single death.");
 }
 
 void command_name(Client *c, const Seperator *sep){


### PR DESCRIPTION
Added options to #setxp to set XP by percentage, to subtract the XP you'd lose on death, and to rez a death.

Added XP stats to #showstats.

Fixed the bogus item error when you interact with a merchant who is full.

Hide will now always make your character appear invisible to yourself, whether it succeeds or not. Other players will only see you disappear if it succeeds.

Charm and Pacify will now almost always fail on reds and yellows.